### PR TITLE
Fix invalid entry warning

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -9,7 +9,9 @@
     "MrJeremyFisher"
   ],
   "license": "Apache",
-  "issues": "${issues_url}",
+  "contact": {
+    "issues": "${issues_url}"
+  },
   "environment": "client",
   "entrypoints": {
     "client": [


### PR DESCRIPTION
Fixes the following warning:

> [13:13:11] [main/INFO]: Loading Minecraft 1.20.4 with Fabric Loader 0.15.11
> [13:13:11] [ForkJoinPool-1-worker-8/WARN]: The mod "combatradar" contains invalid entries in its mod json:
> - Unsupported root entry "issues" at line 12 column 11

This PR puts the "issues" value in the correct place as per the documentation: https://fabricmc.net/wiki/documentation:fabric_mod_json